### PR TITLE
Add blkid-sys bindings directly to the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ authors = ["Chris Holcombe <xfactor973@gmail.com>"]
 categories = ["api-bindings"]
 
 [dependencies]
-blkid-sys = "^0.1"
 libc = "^0.2"
 err-derive = "0.1.5"
+blkid-sys = { path = "./blkid-sys"}
+[workspace]
+members = [
+	"blkid-sys",
+]

--- a/blkid-sys/Cargo.toml
+++ b/blkid-sys/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "blkid-sys"
+version = "0.1.4"
+authors = ["Chris Holcombe <xfactor973@gmail.com>"]
+description = "libblkid raw sys bindings"
+license = "MIT"
+documentation = "https://docs.rs/blkid-sys"
+build = "build.rs"
+categories = ["external-ffi-bindings"]
+[build-dependencies]
+bindgen = "~0.43"
+

--- a/blkid-sys/build.rs
+++ b/blkid-sys/build.rs
@@ -1,0 +1,18 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .rustfmt_bindings(true)
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+     println!("cargo:rustc-link-lib=blkid");
+}

--- a/blkid-sys/src/lib.rs
+++ b/blkid-sys/src/lib.rs
@@ -1,0 +1,11 @@
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    unused,
+    elided_lifetimes_in_paths,
+    clippy::all,
+    unknown_lints
+)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/blkid-sys/wrapper.h
+++ b/blkid-sys/wrapper.h
@@ -1,0 +1,1 @@
+#include <blkid/blkid.h>


### PR DESCRIPTION
Thank you for working on this library -- while using it, I had some issues with versions that were set in the blkid-sys crate on which this library depends. 

IMHO it does not make a whole lot of sense to have a "naked" sys crate if it does not add anything useful other then the bindings itself. The update cycle would be annoying at best i.e:

1) poke the author and wait to accept
2) wait for the crate to be pushed to crates.io
3) send pr here to update binding version

This makes it easier, and possibly in the future can dispense of the bindgen stuff altogether and only really bind to what needs binding.
